### PR TITLE
Fix failing checks: e2e tests, welcome action

### DIFF
--- a/.changeset/thick-trees-punch.md
+++ b/.changeset/thick-trees-punch.md
@@ -1,0 +1,8 @@
+---
+"@pushkin-templates/exp-basic": patch
+"@pushkin-templates/exp-grammaticality-judgment": patch
+"@pushkin-templates/exp-lexical-decision": patch
+"@pushkin-templates/exp-self-paced-reading": patch
+---
+
+Fix logic error that caused the post-experiment feedback page to show the "Oops! Something went wrong" message when the percentile rank and/or summary stat values was 0, which are valid values. Now it checks for null/undefined.

--- a/.github/workflows/welcome.yml
+++ b/.github/workflows/welcome.yml
@@ -13,8 +13,8 @@ jobs:
       - uses: actions/checkout@v3
       - uses: actions/first-interaction@main
         with:
-          repo-token: ${{ secrets.GITHUB_TOKEN }}
-          issue-message: |
+          repo_token: ${{ secrets.GITHUB_TOKEN }}
+          issue_message: |
             👋 
             Thanks for opening this issue! We will investigate the matter and get back to you as soon as possible. In the meantime, double check that your issue:
             
@@ -29,7 +29,7 @@ jobs:
                - [JavaScript Tutorial](https://www.codecademy.com/learn/introduction-to-javascript)
                - [JsPsych Tutorial](https://www.jspsych.org/7.3/tutorials/hello-world/#jspsych-hello-world-experiment)
 
-          pr-message: |
+          pr_message: |
             👋 
             Thanks for making this pull request! We will review it as soon as possible. In the meantime, double check that your PR:
             

--- a/.github/workflows/welcome.yml
+++ b/.github/workflows/welcome.yml
@@ -10,7 +10,6 @@ jobs:
   write-message:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v3
       - uses: actions/first-interaction@main
         with:
           repo_token: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/welcome.yml
+++ b/.github/workflows/welcome.yml
@@ -1,6 +1,7 @@
 name: Welcome new contributors
 
-on: 
+on:
+  workflow_dispatch:
   issues:
     types: [opened]
   pull_request:

--- a/templates/experiments/basic/src/e2e/experiment.test.js
+++ b/templates/experiments/basic/src/e2e/experiment.test.js
@@ -246,7 +246,7 @@ test.describe("Completing the experiment in simulation mode", () => {
     await expect(loadingMessage).toHaveText("Loading...");
 
     // Mock the API response to simulate data being available
-    await page.route("**/api/results", (route) =>
+    await page.route(`**/api/${expInfo.shortName}/getPercentileRank`, (route) =>
       route.fulfill({
         status: 200,
         contentType: "application/json",

--- a/templates/experiments/basic/src/e2e/experiment.test.js
+++ b/templates/experiments/basic/src/e2e/experiment.test.js
@@ -251,9 +251,11 @@ test.describe("Completing the experiment in simulation mode", () => {
         status: 200,
         contentType: "application/json",
         body: JSON.stringify({
-          percentileRank: 75,
-          totalRows: 100,
-          summary_stat: 5000,
+          resData: {
+            percentileRank: 75,
+            totalRows: 100,
+            summary_stat: 5000,
+          },
         }),
       }),
     );

--- a/templates/experiments/basic/src/e2e/experiment.test.js
+++ b/templates/experiments/basic/src/e2e/experiment.test.js
@@ -238,13 +238,6 @@ test.describe("Completing the experiment in simulation mode", () => {
     expect(dbUserResults.user_id).toBe(userResults.user_id);
   });
   test("should produce the expected results page", async ({ page }) => {
-    // Click the link to see results
-    await page.click("text=Click to see your results!");
-
-    // Check that the results page displays the loading message initially
-    const loadingMessage = await page.locator("h1");
-    await expect(loadingMessage).toHaveText("Loading...");
-
     // Mock the API response to simulate data being available
     await page.route(`**/api/${expInfo.shortName}/getPercentileRank`, (route) =>
       route.fulfill({
@@ -260,8 +253,8 @@ test.describe("Completing the experiment in simulation mode", () => {
       }),
     );
 
-    // Reload the page to trigger the API call
-    await page.reload();
+    // Click the link to see results
+    await page.click("text=Click to see your results!");
 
     // Check that the correct results header is displayed
     const resultsHeader = await page.locator("h1");

--- a/templates/experiments/basic/src/e2e/results.test.js
+++ b/templates/experiments/basic/src/e2e/results.test.js
@@ -15,10 +15,15 @@ test.describe("Results page in simulation mode", () => {
   );
 
   test.beforeEach(async ({ page }) => {
+    // Register listener before goto to avoid missing the response
+    const tabulateResponsePromise = page.waitForResponse(
+      `/api/${expInfo.shortName}/tabulateAndPostResults`,
+    );
     // Go to the experiment in simulation mode
     await page.goto(`/quizzes/${expInfo.shortName}?simulate=true`);
-
-    // Wait for the experiment to finish
+    // Wait for tabulateAndPostResults to complete so data is committed to DB
+    await tabulateResponsePromise;
+    // Wait for the experiment finish screen
     await page.waitForSelector("text=Click to see your results!");
   });
 

--- a/templates/experiments/basic/src/web page/src/results.js
+++ b/templates/experiments/basic/src/web page/src/results.js
@@ -77,7 +77,7 @@ const ExpResults = (props) => {
       );
     }
 
-    if (!data.percentileRank || !data.totalRows || !data.summary_stat) {
+    if (data.percentileRank == null || !data.totalRows || data.summary_stat == null) {
       return (
         <div>
           <Container className="mt-5 text-center">

--- a/templates/experiments/grammaticality-judgment/src/e2e/experiment.test.js
+++ b/templates/experiments/grammaticality-judgment/src/e2e/experiment.test.js
@@ -247,9 +247,11 @@ test.describe("Completing the experiment in simulation mode", () => {
         status: 200,
         contentType: "application/json",
         body: JSON.stringify({
-          percentileRank: 75,
-          totalRows: 100,
-          summary_stat: 5000,
+          resData: {
+            percentileRank: 75,
+            totalRows: 100,
+            summary_stat: 5000,
+          },
         }),
       }),
     );

--- a/templates/experiments/grammaticality-judgment/src/e2e/experiment.test.js
+++ b/templates/experiments/grammaticality-judgment/src/e2e/experiment.test.js
@@ -242,7 +242,7 @@ test.describe("Completing the experiment in simulation mode", () => {
     await expect(loadingMessage).toHaveText("Loading...");
 
     // Mock the API response to simulate data being available
-    await page.route("**/api/results", (route) =>
+    await page.route(`**/api/${expInfo.shortName}/getPercentileRank`, (route) =>
       route.fulfill({
         status: 200,
         contentType: "application/json",

--- a/templates/experiments/grammaticality-judgment/src/e2e/experiment.test.js
+++ b/templates/experiments/grammaticality-judgment/src/e2e/experiment.test.js
@@ -234,13 +234,6 @@ test.describe("Completing the experiment in simulation mode", () => {
     expect(dbUserResults.user_id).toBe(userResults.user_id);
   });
   test("should produce the expected results page", async ({ page }) => {
-    // Click the link to see results
-    await page.click("text=Click to see your results!");
-
-    // Check that the results page displays the loading message initially
-    const loadingMessage = await page.locator("h1");
-    await expect(loadingMessage).toHaveText("Loading...");
-
     // Mock the API response to simulate data being available
     await page.route(`**/api/${expInfo.shortName}/getPercentileRank`, (route) =>
       route.fulfill({
@@ -256,8 +249,8 @@ test.describe("Completing the experiment in simulation mode", () => {
       }),
     );
 
-    // Reload the page to trigger the API call
-    await page.reload();
+    // Click the link to see results
+    await page.click("text=Click to see your results!");
 
     // Check that the correct results header is displayed
     const resultsHeader = await page.locator("h1");

--- a/templates/experiments/grammaticality-judgment/src/e2e/results.test.js
+++ b/templates/experiments/grammaticality-judgment/src/e2e/results.test.js
@@ -15,10 +15,15 @@ test.describe("Results page in simulation mode", () => {
   );
 
   test.beforeEach(async ({ page }) => {
+    // Register listener before goto to avoid missing the response
+    const tabulateResponsePromise = page.waitForResponse(
+      `/api/${expInfo.shortName}/tabulateAndPostResults`,
+    );
     // Go to the experiment in simulation mode
     await page.goto(`/quizzes/${expInfo.shortName}?simulate=true`);
-
-    // Wait for the experiment to finish
+    // Wait for tabulateAndPostResults to complete so data is committed to DB
+    await tabulateResponsePromise;
+    // Wait for the experiment finish screen
     await page.waitForSelector("text=Click to see your results!");
   });
 

--- a/templates/experiments/grammaticality-judgment/src/web page/src/results.js
+++ b/templates/experiments/grammaticality-judgment/src/web page/src/results.js
@@ -77,7 +77,7 @@ const ExpResults = (props) => {
       );
     }
 
-    if (!data.percentileRank || !data.totalRows || !data.summary_stat) {
+    if (data.percentileRank == null || !data.totalRows || data.summary_stat == null) {
       return (
         <div>
           <Container className="mt-5 text-center">

--- a/templates/experiments/lexical-decision/src/e2e/experiment.test.js
+++ b/templates/experiments/lexical-decision/src/e2e/experiment.test.js
@@ -247,9 +247,11 @@ test.describe("Completing the experiment in simulation mode", () => {
         status: 200,
         contentType: "application/json",
         body: JSON.stringify({
-          percentileRank: 75,
-          totalRows: 100,
-          summary_stat: 5000,
+          resData: {
+            percentileRank: 75,
+            totalRows: 100,
+            summary_stat: 5000,
+          },
         }),
       }),
     );

--- a/templates/experiments/lexical-decision/src/e2e/experiment.test.js
+++ b/templates/experiments/lexical-decision/src/e2e/experiment.test.js
@@ -242,7 +242,7 @@ test.describe("Completing the experiment in simulation mode", () => {
     await expect(loadingMessage).toHaveText("Loading...");
 
     // Mock the API response to simulate data being available
-    await page.route("**/api/results", (route) =>
+    await page.route(`**/api/${expInfo.shortName}/getPercentileRank`, (route) =>
       route.fulfill({
         status: 200,
         contentType: "application/json",

--- a/templates/experiments/lexical-decision/src/e2e/experiment.test.js
+++ b/templates/experiments/lexical-decision/src/e2e/experiment.test.js
@@ -234,13 +234,6 @@ test.describe("Completing the experiment in simulation mode", () => {
     expect(dbUserResults.user_id).toBe(userResults.user_id);
   });
   test("should produce the expected results page", async ({ page }) => {
-    // Click the link to see results
-    await page.click("text=Click to see your results!");
-
-    // Check that the results page displays the loading message initially
-    const loadingMessage = await page.locator("h1");
-    await expect(loadingMessage).toHaveText("Loading...");
-
     // Mock the API response to simulate data being available
     await page.route(`**/api/${expInfo.shortName}/getPercentileRank`, (route) =>
       route.fulfill({
@@ -256,8 +249,8 @@ test.describe("Completing the experiment in simulation mode", () => {
       }),
     );
 
-    // Reload the page to trigger the API call
-    await page.reload();
+    // Click the link to see results
+    await page.click("text=Click to see your results!");
 
     // Check that the correct results header is displayed
     const resultsHeader = await page.locator("h1");

--- a/templates/experiments/lexical-decision/src/e2e/results.test.js
+++ b/templates/experiments/lexical-decision/src/e2e/results.test.js
@@ -15,10 +15,15 @@ test.describe("Results page in simulation mode", () => {
   );
 
   test.beforeEach(async ({ page }) => {
+    // Register listener before goto to avoid missing the response
+    const tabulateResponsePromise = page.waitForResponse(
+      `/api/${expInfo.shortName}/tabulateAndPostResults`,
+    );
     // Go to the experiment in simulation mode
     await page.goto(`/quizzes/${expInfo.shortName}?simulate=true`);
-
-    // Wait for the experiment to finish
+    // Wait for tabulateAndPostResults to complete so data is committed to DB
+    await tabulateResponsePromise;
+    // Wait for the experiment finish screen
     await page.waitForSelector("text=Click to see your results!");
   });
 

--- a/templates/experiments/lexical-decision/src/web page/src/results.js
+++ b/templates/experiments/lexical-decision/src/web page/src/results.js
@@ -77,7 +77,7 @@ const ExpResults = (props) => {
       );
     }
 
-    if (!data.percentileRank || !data.totalRows || !data.summary_stat) {
+    if (data.percentileRank == null || !data.totalRows || data.summary_stat == null) {
       return (
         <div>
           <Container className="mt-5 text-center">

--- a/templates/experiments/self-paced-reading/src/e2e/experiment.test.js
+++ b/templates/experiments/self-paced-reading/src/e2e/experiment.test.js
@@ -247,9 +247,11 @@ test.describe("Completing the experiment in simulation mode", () => {
         status: 200,
         contentType: "application/json",
         body: JSON.stringify({
-          percentileRank: 75,
-          totalRows: 100,
-          summary_stat: 5000,
+          resData: {
+            percentileRank: 75,
+            totalRows: 100,
+            summary_stat: 5000,
+          },
         }),
       }),
     );

--- a/templates/experiments/self-paced-reading/src/e2e/experiment.test.js
+++ b/templates/experiments/self-paced-reading/src/e2e/experiment.test.js
@@ -242,7 +242,7 @@ test.describe("Completing the experiment in simulation mode", () => {
     await expect(loadingMessage).toHaveText("Loading...");
 
     // Mock the API response to simulate data being available
-    await page.route("**/api/results", (route) =>
+    await page.route(`**/api/${expInfo.shortName}/getPercentileRank`, (route) =>
       route.fulfill({
         status: 200,
         contentType: "application/json",

--- a/templates/experiments/self-paced-reading/src/e2e/experiment.test.js
+++ b/templates/experiments/self-paced-reading/src/e2e/experiment.test.js
@@ -234,13 +234,6 @@ test.describe("Completing the experiment in simulation mode", () => {
     expect(dbUserResults.user_id).toBe(userResults.user_id);
   });
   test("should produce the expected results page", async ({ page }) => {
-    // Click the link to see results
-    await page.click("text=Click to see your results!");
-
-    // Check that the results page displays the loading message initially
-    const loadingMessage = await page.locator("h1");
-    await expect(loadingMessage).toHaveText("Loading...");
-
     // Mock the API response to simulate data being available
     await page.route(`**/api/${expInfo.shortName}/getPercentileRank`, (route) =>
       route.fulfill({
@@ -256,8 +249,8 @@ test.describe("Completing the experiment in simulation mode", () => {
       }),
     );
 
-    // Reload the page to trigger the API call
-    await page.reload();
+    // Click the link to see results
+    await page.click("text=Click to see your results!");
 
     // Check that the correct results header is displayed
     const resultsHeader = await page.locator("h1");

--- a/templates/experiments/self-paced-reading/src/e2e/results.test.js
+++ b/templates/experiments/self-paced-reading/src/e2e/results.test.js
@@ -15,10 +15,15 @@ test.describe("Results page in simulation mode", () => {
   );
 
   test.beforeEach(async ({ page }) => {
+    // Register listener before goto to avoid missing the response
+    const tabulateResponsePromise = page.waitForResponse(
+      `/api/${expInfo.shortName}/tabulateAndPostResults`,
+    );
     // Go to the experiment in simulation mode
     await page.goto(`/quizzes/${expInfo.shortName}?simulate=true`);
-
-    // Wait for the experiment to finish
+    // Wait for tabulateAndPostResults to complete so data is committed to DB
+    await tabulateResponsePromise;
+    // Wait for the experiment finish screen
     await page.waitForSelector("text=Click to see your results!");
   });
 

--- a/templates/experiments/self-paced-reading/src/web page/src/results.js
+++ b/templates/experiments/self-paced-reading/src/web page/src/results.js
@@ -77,7 +77,7 @@ const ExpResults = (props) => {
       );
     }
 
-    if (!data.percentileRank || !data.totalRows || !data.summary_stat) {
+    if (data.percentileRank == null || !data.totalRows || data.summary_stat == null) {
       return (
         <div>
           <Container className="mt-5 text-center">


### PR DESCRIPTION
This PR fixes some bugs in the e2e tests and results page:

`e2e/experiment.test.js`
- Incorrect URL was used in the API mock (should be `**/api/${expInfo.shortName}/getPercentileRank` instead of `**/api/results`).
- Removed test for "Loading..." text - this state is too brief to test reliably.
- Mocked API response was returning the results in an incorrect format - needs to be wrapped in a `resData` object.
- API mock needs to be set up before the page click, so that it catches the request (no reload needed).

`e2e/results.test.js`
- In the `beforeEach`, use `page.waitForResponse` to make sure that the API post request has finished before checking results. Previously this was just using the DOM content to check that the results are ready, but the POST request and database update could still have been pending, which was causing intermittent errors.

`templates/experiments/[EXP]/src/web page/src/results.js`
- Fix logic error that determines whether the page should show the "Oops! Something went wrong" message. The previous logic used a falsy check for `data.percentileRank` and `data.summary_stat`, so when those values were 0 (valid), it produced the error message. Now it checks for `null`/`undefined`. (I didn't change the falsy `!data.totalRows` check. A value of 0 is valid, but that case is handled earlier - it produces a "Results aren't available" message). This issue was causing one of the e2e tests to fail.

This also fixes some bugs in the failing 'welcome' Github Workflow: `.github/workflows/welcome.yml`
- The actions/first-interaction action updated its API to use underscores, but the config was still using the old hyphenated names.
- Removes the unnecessary actions/checkout@v3 step. The actions/first-interaction only needs the GitHub token to post a comment, not the repository contents, and the repo cloning step takes a very long time.
- Adds a manual dispatch option to the welcome action, for easier testing (this action only runs on newly-opened PRs/issues, which makes it hard to test changes).