### PR TITLE
check for .yalc/ and yalc.lock, and create these if needed

### DIFF
--- a/.changeset/stale-brooms-count.md
+++ b/.changeset/stale-brooms-count.md
@@ -1,0 +1,5 @@
+---
+"pushkin-cli": patch
+---
+
+Fix Docker COPY error when running pushkin prep on a site with no experiments installed.

--- a/packages/pushkin-cli/src/commands/prep/index.js
+++ b/packages/pushkin-cli/src/commands/prep/index.js
@@ -1,4 +1,5 @@
 import path from "path";
+import os from "os";
 //import { promises as fs } from 'fs';
 import fs from "graceful-fs";
 import jsYaml from "js-yaml";
@@ -694,6 +695,17 @@ export const prep = async (experimentsDir, coreDir, verbose) => {
     process.exit();
   }
 
+  // The API Dockerfile always copies .yalc/ and yalc.lock (added by `yalc add` when
+  // experiments are installed). On a fresh site with no experiments, these don't exist
+  // yet and Docker COPY fails. Create empty placeholders if needed.
+  const apiDir = path.join(coreDir, "api");
+  if (!fs.existsSync(path.join(apiDir, ".yalc"))) {
+    fs.mkdirSync(path.join(apiDir, ".yalc"));
+  }
+  if (!fs.existsSync(path.join(apiDir, "yalc.lock"))) {
+    fs.writeFileSync(path.join(apiDir, "yalc.lock"), '{"version":"v1","packages":{}}');
+  }
+
   if (verbose) console.log("Building API");
   let builtAPI;
   try {
@@ -702,6 +714,15 @@ export const prep = async (experimentsDir, coreDir, verbose) => {
     console.error(`Problem building API`);
     throw e;
   }
+  // Same as above — front-end Dockerfile also copies .yalc/ and yalc.lock.
+  const feDir = path.join(coreDir, "front-end");
+  if (!fs.existsSync(path.join(feDir, ".yalc"))) {
+    fs.mkdirSync(path.join(feDir, ".yalc"));
+  }
+  if (!fs.existsSync(path.join(feDir, "yalc.lock"))) {
+    fs.writeFileSync(path.join(feDir, "yalc.lock"), '{"version":"v1","packages":{}}');
+  }
+
   if (verbose) console.log("Building server");
   let builtServer;
   try {


### PR DESCRIPTION
Fixes #380

The Dockerfiles for API and front-end try to copy `.yalc/` and `yalc.lock`, which are created when experiments are installed. If a site is installed but no experiments have been installed yet, then `pushkin prep` will produce an error because these files don't exist. This PR fixes the problem by checking for the existence of the directory and file, and creating a placeholder if they do not exist.

## Steps to reproduce

- On `fix/aws-deployment` (the base branch), run `yarn workspaces run build` to build packages.
- Run `pushkin install site` (using local pushkin) to install a new site. Do not install any experiments. 
- Run `pushkin prep`. You will see the error:

```bash
Dockerfile:4
--------------------
 2 |     
 3 |     COPY ./src /usr/src/app/src
 4 | >>> COPY .yalc /usr/src/app/.yalc/
 5 |     COPY ./package.json ./yarn.lock ./.babelrc ./yalc.lock ./dockerStart.sh /usr/src/app/
 6 |     
--------------------
ERROR: failed to solve: failed to compute cache key: failed to calculate checksum of ref c3479bfb-5945-45c3-92ae-49c72620f001::pn5ialj989lvreg0siwxy5zu8: "/.yalc": not found
```

- Switch to this branch (`fix/docker-copy-error`) and repeat the steps above. Running `pushkin prep` should succeed.
- Run `pushkin install experiment` to install an experiment, then `pushkin prep`. The yalc directory and `yalc.lock` file should not be overwritten with placeholders.

