### PR TITLE
Fix error catching with execFile and docker builds

### DIFF
--- a/packages/pushkin-cli/src/commands/aws/index.js
+++ b/packages/pushkin-cli/src/commands/aws/index.js
@@ -3034,9 +3034,8 @@ const rebuildWorker = async function (exp) {
   const workerName = `${exp}_worker`.toLowerCase(); //Docker names must all be lower case
   const workerLoc = path.join(expDir, workerConfig.location);
 
-  let workerBuild;
   try {
-    workerBuild = execFile("docker", [
+    await execFile("docker", [
       "buildx",
       "build",
       "--platform",
@@ -3047,10 +3046,15 @@ const rebuildWorker = async function (exp) {
       "--load",
     ]);
   } catch (e) {
+    if (e.stderr && (e.stderr.includes("timeout") || e.stderr.includes("network"))) {
+      throw new Error(
+        `Network error while building worker image for ${exp}. ` +
+          `This is usually transient — please try running the command again.`,
+      );
+    }
     console.error(`Problem building worker for ${exp}`);
     throw e;
   }
-  return workerBuild;
 };
 
 /**

--- a/packages/pushkin-cli/src/commands/prep/index.js
+++ b/packages/pushkin-cli/src/commands/prep/index.js
@@ -563,17 +563,15 @@ export const prep = async (experimentsDir, coreDir, verbose) => {
     // Use internal container port (5432), not host-mapped port
     compFile.services[workerName].environment.TRANS_PORT = "5432";
 
-    let workerBuild;
     try {
       if (verbose) console.log(`Building docker image for ${workerName}`);
       const dockerArgs = ["build", workerLoc, "-t", workerName, "--load"];
       if (verbose) console.log("docker", dockerArgs.join(" "));
-      workerBuild = execFile("docker", dockerArgs);
+      await execFile("docker", dockerArgs);
     } catch (e) {
       console.error(`Problem building worker for ${exp}`);
       throw e;
     }
-    return workerBuild;
   };
 
   const composeFileLoc = path.join(path.join(process.cwd(), "pushkin"), "docker-compose.dev.yml");


### PR DESCRIPTION
Fixes #407

This PR fixes an issue with catching errors in docker builds. The builds are called via `execFile` in a try/catch block, but `execFile` was not `await`ed, so the catch blocks would never run. Now docker build errors are properly caught and re-thrown. 

This also checks for a network timeout message for the docker build via `aws init`. This build command is susceptible to these errors due to QEMU emulation for cross-platform builds (`--platform linux/amd64`). (We could add the same check for the build in `prep`, but the network timeout issue much less likely to occur with native builds).